### PR TITLE
Fix failing size() calls & exclude dataURIs from xlink:href detection

### DIFF
--- a/lib/svg-cleaner.js
+++ b/lib/svg-cleaner.js
@@ -217,7 +217,7 @@ function findReferencedElements() {
 
     // if xlink:href is set, then grab the id
     var href = $node.attr('xlink:href');
-    if(href) {
+    if(href && (href.indexOf('data:') !== 0)) {
       addReferencingElement(ids, href, REFERENCE_TYPE.XLINK, node);
     }
 


### PR DESCRIPTION
Hi Michael,

I encountered two problems with SVG-Cleaner, both somehow related to each other:
1. When a cheerio `find()` call fails for some reason (see 2.), it returns an empty array `[]`, which doesn't have a `size()` method and thus results in an error (the process exits). As the `size()` method does nothing else than returning the `length` property (which is a native Array property as well as you know), I simply changed it to this. Not really nice, I know, but effective. I'd leave it up to you how you'd like to fix this issue though ...
2. I happened to encounter an SVG file containing a data URI as the value of an `xlink:href` attribute (don't really know if this valid at all, but this is what the SVG was like). Your `findReferencedElements()` method would accept this as a valid ID reference (which it isn't of course), leading to an error (being the reason for 1.). This pull request includes a patch that prevents those data URIs from being registered as ID references.

Btw. do you intend to work on SVG-Cleaner any longer? Port the missing parts of Scour? Scour itself _might_ be improved in the future, as there's [a new maintainer](https://github.com/oberstet/scour) (@oberstet) now ...

Cheers,
Joschi
