### PR TITLE
Expose the removal of empty containers (metadata, defs, g) to the chainable interface

### DIFF
--- a/lib/svg-cleaner.js
+++ b/lib/svg-cleaner.js
@@ -393,6 +393,23 @@ function removeUnreferencedElements() {
 
 }
 
+// scour:
+// > remove empty defs, metadata, g
+// > NOTE: these elements will be removed if they just have whitespace-only text nodes
+// @extended: also removes nested empty elements <defs><g></g></defs>
+function removeEmptyContainers() {
+  var elementWasRemoved = true;
+  do {
+    elementWasRemoved = false;
+    _($('defs, metadata, g')).each(function(node) {
+      if(!node.children.length) {
+        $(node).remove();
+        elementWasRemoved = true;
+      }
+    });
+  } while(elementWasRemoved);
+}
+
 // ----------- ----------- ----------- ----------- ----------- -----------
 
 // Namspace
@@ -722,7 +739,9 @@ var exposed = {
   'repairStyles': repairStyles,
   'removeNSElements': removeNamespacedElements,
   'removeNSAttributes': removeNamespacedAttributes,
-  'removeUnreferencedElements': removeUnreferencedElements
+  'removeUnreferencedElements': removeUnreferencedElements,
+  'removeEmptyContainers': removeEmptyContainers,
+  'removeUnreferencedIDs': removeUnreferencedIDs
 };
 
 _(exposed).each(function(f, name) {
@@ -771,18 +790,7 @@ SVGCleaner.prototype.clean = function() {
   // scour:
   // > remove empty defs, metadata, g
   // > NOTE: these elements will be removed if they just have whitespace-only text nodes
-
-  // @extended: also removes nested empty elements <defs><g></g></defs>
-  var elementWasRemoved = true;
-  do {
-    elementWasRemoved = false;
-    _($('defs, metadata, g')).each(function(node) {
-      if(!node.children.length) {
-        $(node).remove();
-        elementWasRemoved = true;
-      }
-    });
-  } while(elementWasRemoved);
+  removeEmptyContainers();
 
   removeUnreferencedIDs();
 


### PR DESCRIPTION
The code block taking care of the removal of empty container elements (metadata, defs, g) is the only one that's inlined into the `clean()` method, thus making it impossible to reproduce the complete functionality of this method using the chainable interface (which deserves being better documented btw). I know that this is the same in the original Scour sources as well, but I don't see the the advantage in sticking to the original here.

Also, could you please consider releasing a new NPM package so that one can update the dependencies accordingly? Thanks a lot!

Cheers,
Joschi
