### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var cleanedSvgString = require('svg-cleaner').clean(svgString);
 ```
 
 ```js
-require('svg-cleaner').cleanFileSync(srcFilename, targetFilename);
+require('svg-cleaner').cleanFile(srcFilename, targetFilename);
 ```
 
 As module - chainable interface


### PR DESCRIPTION
Hi,

The Readme says to call the `cleanFileSync` function to compress your svg file, but I was getting this error:

```
Warning: Object #<Object> has no method 'cleanFileSync
```

The module.export function is actually called `cleanFile`, so I've updated the readme.
